### PR TITLE
Improvements to the Tea packet system

### DIFF
--- a/src/TeaFramework/API/Features/Packets/IPacketData.cs
+++ b/src/TeaFramework/API/Features/Packets/IPacketData.cs
@@ -1,12 +1,9 @@
-﻿using System.IO;
-
-namespace TeaFramework.API.Features.Packets
+﻿namespace TeaFramework.API.Features.Packets
 {
     /// <summary>
     ///     Represents serializable packet data.
     /// </summary>
     public interface IPacketData
     {
-        void SerializePacket(BinaryWriter writer);
     }
 }

--- a/src/TeaFramework/API/Features/Packets/IPacketHandler.cs
+++ b/src/TeaFramework/API/Features/Packets/IPacketHandler.cs
@@ -5,7 +5,7 @@ using Terraria.ModLoader;
 namespace TeaFramework.API.Features.Packets
 {
     /// <summary>
-    ///     Handles reading and writing packets.
+    ///     Handles reading and writing packets. Only functions when the specified <see cref="IPacketData"/> is passed into <see cref="IPacketHandler.Write(BinaryWriter, IPacketData?)"/>.
     /// </summary>
     /// <remarks>
     ///     This interface implements <see cref="ILoadable" />.
@@ -36,6 +36,9 @@ namespace TeaFramework.API.Features.Packets
     /// </remarks>
     public interface IPacketHandler : ILoadable
     {
+        /// <summary>
+        /// The <see cref="IPacketHandler"/> id, unique within the mod it belongs to.
+        /// </summary>
         byte Id { get; set; }
 
         /// <summary>

--- a/src/TeaFramework/API/Features/Packets/IPacketHandler.cs
+++ b/src/TeaFramework/API/Features/Packets/IPacketHandler.cs
@@ -7,14 +7,17 @@ namespace TeaFramework.API.Features.Packets
     /// <summary>
     ///     Handles reading and writing packets.
     /// </summary>
-    /// <typeparam name="TPacketData"></typeparam>
-    public interface IPacketHandler<in TPacketData> : IPacketHandler
+    /// <remarks>
+    ///     This interface implements <see cref="ILoadable" />.
+    /// </remarks>
+    public interface IPacketHandlerWithData<in TPacketData> : IPacketHandler
         where TPacketData : IPacketData
     {
-        Type IPacketHandler.HandledType => typeof(TPacketData);
+        void IPacketHandler.Write(BinaryWriter writer, IPacketData? packetData) {
+            if (packetData is null)
+                throw new ArgumentNullException(nameof(packetData), $"\"{nameof(packetData)}\" cannot be null in IPacketHandlerWithData.Write");
 
-        void IPacketHandler.WritePacket(BinaryWriter writer, IPacketData packetData) {
-            WritePacket(writer, (TPacketData) packetData);
+            Write(writer, (TPacketData) packetData);
         }
 
         /// <summary>
@@ -22,34 +25,38 @@ namespace TeaFramework.API.Features.Packets
         /// </summary>
         /// <param name="writer">The writer to write with.</param>
         /// <param name="packetData">The packet data to serialize.</param>
-        void WritePacket(BinaryWriter writer, TPacketData packetData);
+        void Write(BinaryWriter writer, TPacketData packetData);
     }
 
     /// <summary>
     ///     Handles reading and writing packets.
     /// </summary>
     /// <remarks>
-    ///     This interface extends <see cref="ILoadable" />.
+    ///     This interface implements <see cref="ILoadable" />.
     /// </remarks>
     public interface IPacketHandler : ILoadable
     {
-        /// <summary>
-        ///     The packet data type to handle.
-        /// </summary>
-        Type HandledType { get; }
+        byte Id { get; set; }
 
         /// <summary>
-        ///     Writes a packet.
+        ///     Writes to a <see cref="BinaryWriter"/>.
         /// </summary>
-        /// <param name="writer">The writer to write with.</param>
+        /// <param name="writer">The writer to write to.</param>
         /// <param name="packetData">The packet data to serialize.</param>
-        void WritePacket(BinaryWriter writer, IPacketData packetData);
+        void Write(BinaryWriter writer, IPacketData? packetData = null);
 
         /// <summary>
         ///     Reads a packet.
         /// </summary>
-        /// <param name="reader">The reader to read with.</param>
+        /// <param name="reader">The reader to read from.</param>
         /// <param name="whoAmI">The ID of the player sending the packet.</param>
         void ReadPacket(BinaryReader reader, int whoAmI);
+
+        // Default impls for 100% less boilerplate.
+        void ILoadable.Load(Mod mod) {
+        }
+
+        void ILoadable.Unload() {
+        }
     }
 }

--- a/src/TeaFramework/API/Features/Packets/IPacketManager.cs
+++ b/src/TeaFramework/API/Features/Packets/IPacketManager.cs
@@ -15,14 +15,14 @@ namespace TeaFramework.API.Features.Packets
         ITeaMod TeaMod { get; }
 
         /// <summary>
-        ///     Type to packet handler map, where the type represents the type of a packet data object.
-        /// </summary>
-        Dictionary<Type, IPacketHandler> PacketHandlers { get; }
-
-        /// <summary>
         ///     Packet handler ID to packet handler map.
         /// </summary>
-        Dictionary<byte, IPacketHandler> PacketHandlersFromId { get; }
+        Dictionary<byte, IPacketHandler> PacketHandlers { get; }
+
+        /// <summary>
+        ///     Packet handler <see cref="Type"/> to packet handler ID.
+        /// </summary>
+        Dictionary<Type, byte> PacketHandlerTypeToId { get; }
 
         /// <summary>
         ///     Registers a packet handler.
@@ -31,17 +31,11 @@ namespace TeaFramework.API.Features.Packets
         void RegisterPacketHandler(IPacketHandler handler);
 
         /// <summary>
-        ///     Initiates the writing of a packet from the given packet data.
-        /// </summary>
-        /// <param name="packetData">The packet data to write.</param>
-        void WritePacketFromData(IPacketData packetData);
-
-        /// <summary>
         ///     Writes a packet to the binary writer with the given packet data.
         /// </summary>
         /// <param name="writer">The writer to write with.</param>
         /// <param name="packetData"></param>
-        void WritePacket(BinaryWriter writer, IPacketData packetData);
+        void WritePacket(BinaryWriter writer, byte packetId, IPacketData? packetData = null);
 
         /// <summary>
         ///     Reads a packet using the given reader.

--- a/src/TeaFramework/Utilities/NetUtils.cs
+++ b/src/TeaFramework/Utilities/NetUtils.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.IO;
+using TeaFramework.API;
+using TeaFramework.API.Features.Packets;
+using Terraria.ModLoader;
+
+namespace TeaFramework.Utilities
+{
+    /// <summary>
+    ///     Utilities for net syncing.
+    /// </summary>
+    public static class NetUtils
+    {
+        /// <summary>
+        /// Write the specified packet 
+        /// </summary>
+        /// <typeparam name="TPacket">The packet to write.</typeparam>
+        /// <param name="writer">The <see cref="BinaryWriter"/> to write to.</param>
+        /// <param name="teaMod">The mod the packet belongs to.</param>
+        /// <param name="packetData"><see cref="IPacketData"/> to use when writing the packet/.</param>
+        /// <exception cref="InvalidOperationException">Thrown if <paramref name="teaMod"/> does not have a registered <see cref="IPacketManager"/></exception>
+        public static void WritePacket<TPacket>(BinaryWriter writer, ITeaMod teaMod, IPacketData? packetData = null) where TPacket : IPacketHandler {
+            IPacketManager? manager = teaMod.ServiceProvider.GetServiceSingleton<IPacketManager>();
+            if (manager is null)
+                throw new InvalidOperationException($"{teaMod.ModInstance.Name} does not have a {nameof(IPacketManager)} registered.");
+
+            manager.WritePacket(writer, manager.PacketHandlerTypeToId[typeof(TPacket)], packetData);
+        }
+
+        /// <summary>
+        /// Create a <see cref="ModPacket"/>, write <typeparamref name="TPacket"/> to it, and send it.
+        /// </summary>
+        /// <typeparam name="TPacket">The packet to write.</typeparam>
+        /// <param name="teaMod">The mod the packet belongs to.</param>
+        /// <param name="packetData"><see cref="IPacketData"/> to use when writing the packet/.</param>
+        /// <exception cref="InvalidOperationException">Thrown if <paramref name="teaMod"/> does not have a registered <see cref="IPacketManager"/></exception>
+        public static void WriteAndSendPacket<TPacket>(ITeaMod teaMod, IPacketData? packetData = null) where TPacket : IPacketHandler {
+            ModPacket packet = teaMod.ModInstance.GetPacket();
+            WritePacket<TPacket>(packet, teaMod, packetData);
+            packet.Send();
+        }
+    }
+}


### PR DESCRIPTION
While the current Tea packet system is way better than the tModLoader system, it leaves a lot to be desired. This PR aims to fix those issues by:
* Removed the `SerializePacket` method from IPacketData: It is a leftover from the original API design which never saw the light of day.
* Decoupled `IPacketHandler` and `IPacketData`, making it possible to create a packet handler without a specific data type.
* Simplified many method names from `WritePacket` to `Write` to better represent what they actually do.
* IPacketManager no longer holds two instances of each IPacketHandler.
* Added a NetUtils class for easy reading and writing.